### PR TITLE
Q2 2026 — System.Text.Json migration + quarterly work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,16 +55,26 @@ jobs:
           $deps = $buildOrder[0..($buildOrder.Count-2)]
           foreach ($r in $deps) {
             if (Test-Path $r) { continue }
-            $preferredBranch = 'sow/2026-Q2'
-            $hasPreferred = (git ls-remote --heads "https://github.com/$org/$r.git" $preferredBranch 2>$null | Out-String).Trim()
-            if ($hasPreferred) {
-              Write-Host "Cloning $org/$r @ $preferredBranch"
-              git clone --depth 1 --branch $preferredBranch "https://github.com/$org/$r.git" $r
-            } else {
+            $headRef = '${{ github.head_ref }}'
+            $candidates = @()
+            if ($headRef) { $candidates += $headRef }
+            $candidates += 'sow/2026-Q2'
+            $cloned = $false
+            foreach ($cand in $candidates) {
+              $has = (git ls-remote --heads "https://github.com/$org/$r.git" $cand 2>$null | Out-String).Trim()
+              if ($has) {
+                Write-Host "Cloning $org/$r @ $cand"
+                git clone --depth 1 --branch $cand "https://github.com/$org/$r.git" $r
+                $cloned = $true
+                break
+              }
+            }
+            if (-not $cloned) {
               Write-Host "Cloning $org/$r @ default branch"
               git clone --depth 1 "https://github.com/$org/$r.git" $r
             }
           }
+
 
           # Ensure ReferencePath exists even before SAM_Windows builds
           New-Item -ItemType Directory -Force -Path "SAM_Windows\build" | Out-Null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build (Windows)
 
 on:
   push:
-    branches: [ "master", "main" ]
+    branches: [ "master", "main", "sow/2026-Q2" ]
   pull_request:
-    branches: [ "master", "main" ]
+    branches: [ "master", "main", "sow/2026-Q2" ]
   workflow_dispatch:
 
 jobs:
@@ -55,8 +55,15 @@ jobs:
           $deps = $buildOrder[0..($buildOrder.Count-2)]
           foreach ($r in $deps) {
             if (Test-Path $r) { continue }
-            Write-Host "Cloning https://github.com/$org/$r.git"
-            git clone --depth 1 "https://github.com/$org/$r.git" $r
+            $preferredBranch = 'sow/2026-Q2'
+            $hasPreferred = (git ls-remote --heads "https://github.com/$org/$r.git" $preferredBranch 2>$null | Out-String).Trim()
+            if ($hasPreferred) {
+              Write-Host "Cloning $org/$r @ $preferredBranch"
+              git clone --depth 1 --branch $preferredBranch "https://github.com/$org/$r.git" $r
+            } else {
+              Write-Host "Cloning $org/$r @ default branch"
+              git clone --depth 1 "https://github.com/$org/$r.git" $r
+            }
           }
 
           # Ensure ReferencePath exists even before SAM_Windows builds

--- a/.github/workflows/spdx-check.yml
+++ b/.github/workflows/spdx-check.yml
@@ -2,44 +2,89 @@ name: SPDX + Copyright header check
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   spdx:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Check header in changed .cs files
+        shell: bash
         run: |
-          set -e
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
+          set -euo pipefail
 
-          FILES=$(git diff --name-only "$BASE" "$HEAD" -- '*.cs' || true)
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            HEAD="${{ github.sha }}"
+            BASE="$(git rev-parse "${HEAD}^" 2>/dev/null || true)"
+          fi
 
-          if [ -z "$FILES" ]; then
+          echo "Base SHA: ${BASE:-<none>}"
+          echo "Head SHA: $HEAD"
+          echo
+
+          if [ -z "${BASE:-}" ]; then
+            mapfile -t files < <(git ls-files '*.cs')
+          else
+            mapfile -t files < <(git diff --diff-filter=ACMR --name-only "$BASE" "$HEAD" -- '*.cs' || true)
+          fi
+
+          if [ "${#files[@]}" -eq 0 ]; then
             echo "No C# files changed."
             exit 0
           fi
 
-          MISSING=""
-          for f in $FILES; do
-            HEADBLOCK=$(head -n 6 "$f")
+          echo "Changed C# files:"
+          printf ' - %s\n' "${files[@]}"
+          echo
 
-            echo "$HEADBLOCK" | grep -q "// SPDX-License-Identifier: LGPL-3.0-or-later" || MISSING="$MISSING $f"
-            echo "$HEADBLOCK" | grep -q "// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors" || MISSING="$MISSING $f"
+          missing=()
+
+          for f in "${files[@]}"; do
+            if [ ! -f "$f" ]; then
+              echo "Skipping missing file: $f"
+              continue
+            fi
+
+            headblock="$(head -n 20 "$f" | sed '1s/^\xEF\xBB\xBF//' | tr -d '\r')"
+
+            echo "Checking: $f"
+
+            if ! grep -q "SPDX-License-Identifier: LGPL-3.0-or-later" <<< "$headblock"; then
+              echo "  Missing SPDX line"
+              missing+=("$f")
+              continue
+            fi
+
+            if ! grep -qE "Copyright \(c\) 2020[-–]2026 Michal Dengusiak & Jakub Ziolkowski and contributors" <<< "$headblock"; then
+              echo "  Missing copyright line"
+              missing+=("$f")
+              continue
+            fi
+
+            echo "  OK"
           done
 
-          if [ -n "$MISSING" ]; then
-            echo "❌ Missing required header in:"
-            for f in $MISSING; do echo " - $f"; done
-            echo ""
-            echo "Each changed .cs file must start with:"
+          echo
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "Missing required header in:"
+            printf ' - %s\n' "${missing[@]}"
+            echo
+            echo "Each checked .cs file must contain within the first 20 lines:"
             echo "// SPDX-License-Identifier: LGPL-3.0-or-later"
-            echo "// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors"
+            echo "// Copyright (c) 2020-2026 Michal Dengusiak & Jakub Ziolkowski and contributors"
             exit 1
           fi
 
-          echo "✅ SPDX + copyright headers OK."
+          echo "SPDX + copyright headers OK."

--- a/Grasshopper/SAM.Core.Grasshopper.Building/SAM.Core.Grasshopper.Building.csproj
+++ b/Grasshopper/SAM.Core.Grasshopper.Building/SAM.Core.Grasshopper.Building.csproj
@@ -48,9 +48,7 @@
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.3</Version>
-    </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SAM_Building\SAM.Core.Building\SAM.Core.Building.csproj" />

--- a/Grasshopper/SAM.Geometry.Grasshopper.Building/SAM.Geometry.Grasshopper.Building.csproj
+++ b/Grasshopper/SAM.Geometry.Grasshopper.Building/SAM.Geometry.Grasshopper.Building.csproj
@@ -64,9 +64,7 @@
     <PackageReference Include="NetTopologySuite">
       <Version>2.5.0</Version>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.3</Version>
-    </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Rhino\SAM.Core.Building.Rhino\SAM.Core.Building.Rhino.csproj" />

--- a/Rhino/SAM.Core.Building.Rhino/SAM.Core.Building.Rhino.csproj
+++ b/Rhino/SAM.Core.Building.Rhino/SAM.Core.Building.Rhino.csproj
@@ -31,9 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -45,9 +42,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Rhino/SAM.Core.Building.Rhino/packages.config
+++ b/Rhino/SAM.Core.Building.Rhino/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
-</packages>

--- a/Rhino/SAM.Geometry.Building.Rhino/Modify/BakeGeometry.cs
+++ b/Rhino/SAM.Geometry.Building.Rhino/Modify/BakeGeometry.cs
@@ -1,4 +1,6 @@
-﻿using Rhino;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using Rhino;
 using Rhino.DocObjects;
 using Rhino.Geometry;
 using System;

--- a/Rhino/SAM.Geometry.Building.Rhino/Modify/BakeGeometry.cs
+++ b/Rhino/SAM.Geometry.Building.Rhino/Modify/BakeGeometry.cs
@@ -32,7 +32,7 @@ namespace SAM.Geometry.Building.Rhino
             GeometryBase geometryBase = rhinoDoc.Objects.FindGeometry(guid);
             if (geometryBase != null)
             {
-                string @string = partition.ToJObject()?.ToString();
+                string @string = partition.ToJsonObject()?.ToString();
                 if (!string.IsNullOrWhiteSpace(@string))
                     geometryBase.SetUserString("SAM", @string);
             }
@@ -56,7 +56,7 @@ namespace SAM.Geometry.Building.Rhino
             GeometryBase geometryBase = rhinoDoc.Objects.FindGeometry(guid);
             if (geometryBase != null)
             {
-                string @string = opening.ToJObject()?.ToString();
+                string @string = opening.ToJsonObject()?.ToString();
                 if (!string.IsNullOrWhiteSpace(@string))
                     geometryBase.SetUserString("SAM", @string);
             }

--- a/Rhino/SAM.Geometry.Building.Rhino/SAM.Geometry.Building.Rhino.csproj
+++ b/Rhino/SAM.Geometry.Building.Rhino/SAM.Geometry.Building.Rhino.csproj
@@ -36,9 +36,6 @@
     <Reference Include="Eto, Version=2.5.0.0, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
       <HintPath>..\..\packages\RhinoCommon.6.32.20340.21001\lib\net45\Eto.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="Rhino.UI, Version=6.32.20340.21000, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
       <HintPath>..\..\packages\RhinoCommon.6.32.20340.21001\lib\net45\Rhino.UI.dll</HintPath>
     </Reference>
@@ -65,6 +62,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Text.Json">
+      <HintPath>$(NuGetPackageRoot)system.text.json\10.0.8\lib\net462\System.Text.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Rhino/SAM.Geometry.Building.Rhino/packages.config
+++ b/Rhino/SAM.Geometry.Building.Rhino/packages.config
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
   <package id="RhinoCommon" version="6.32.20340.21001" targetFramework="net472" />
 </packages>

--- a/SAM_Building/SAM.Core.Building/Classes/BuildingElementType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/BuildingElementType.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-
+﻿using System.Text.Json.Nodes;
 namespace SAM.Core.Building
 {
     public abstract class BuildingElementType : SAMType, IBuildingObject
@@ -16,7 +15,7 @@ namespace SAM.Core.Building
 
         }
 
-        public BuildingElementType(JObject jObject)
+        public BuildingElementType(JsonObject jObject)
             : base(jObject)
         {
 
@@ -34,17 +33,17 @@ namespace SAM.Core.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
                 return jObject;

--- a/SAM_Building/SAM.Core.Building/Classes/BuildingElementType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/BuildingElementType.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 namespace SAM.Core.Building
 {
     public abstract class BuildingElementType : SAMType, IBuildingObject

--- a/SAM_Building/SAM.Core.Building/Classes/ConstructionLayer.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/ConstructionLayer.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Architectural;
 
 namespace SAM.Core.Building

--- a/SAM_Building/SAM.Core.Building/Classes/ConstructionLayer.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/ConstructionLayer.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Architectural;
 
 namespace SAM.Core.Building
@@ -16,15 +16,15 @@ namespace SAM.Core.Building
 
         }
 
-        public ConstructionLayer(JObject jObject)
+        public ConstructionLayer(JsonObject jObject)
             : base(jObject)
         {
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
             {
                 return false;
             }
@@ -32,9 +32,9 @@ namespace SAM.Core.Building
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
             {
                 return jObject;

--- a/SAM_Building/SAM.Core.Building/Classes/DoorType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/DoorType.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Architectural;
 using System.Collections.Generic;
 
@@ -18,7 +18,7 @@ namespace SAM.Core.Building
 
         }
 
-        public DoorType(JObject jObject)
+        public DoorType(JsonObject jObject)
             : base(jObject)
         {
 
@@ -48,17 +48,17 @@ namespace SAM.Core.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
                 return jObject;

--- a/SAM_Building/SAM.Core.Building/Classes/DoorType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/DoorType.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Architectural;
 using System.Collections.Generic;
 

--- a/SAM_Building/SAM.Core.Building/Classes/FloorType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/FloorType.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System.Collections.Generic;
 
 using SAM.Architectural;

--- a/SAM_Building/SAM.Core.Building/Classes/FloorType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/FloorType.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using System.Collections.Generic;
 
 using SAM.Architectural;
@@ -13,7 +13,7 @@ namespace SAM.Core.Building
 
         }
 
-        public FloorType(JObject jObject)
+        public FloorType(JsonObject jObject)
             : base(jObject)
         {
 
@@ -49,17 +49,17 @@ namespace SAM.Core.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
                 return jObject;

--- a/SAM_Building/SAM.Core.Building/Classes/HostPartitionType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/HostPartitionType.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-
+﻿using System.Text.Json.Nodes;
 using System.Collections.Generic;
 using System.Linq;
 using SAM.Architectural;
@@ -16,7 +15,7 @@ namespace SAM.Core.Building
 
         }
 
-        public HostPartitionType(JObject jObject)
+        public HostPartitionType(JsonObject jObject)
             : base(jObject)
         {
 
@@ -120,26 +119,34 @@ namespace SAM.Core.Building
             return result;
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             if (jObject.ContainsKey("MaterialLayers"))
-                materialLayers = Core.Create.IJSAMObjects<MaterialLayer>(jObject.Value<JArray>("MaterialLayers"));
+                materialLayers = Core.Create.IJSAMObjects<MaterialLayer>(jObject["MaterialLayers"] as JsonArray);
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
                 return jObject;
 
             if (materialLayers != null)
-                jObject.Add("MaterialLayers", Core.Create.JArray(materialLayers));
+            {
+                JsonArray jArray = new JsonArray();
+                foreach (MaterialLayer materialLayer in materialLayers)
+                {
+                    jArray.Add(materialLayer?.ToJsonObject());
+                }
+
+                jObject.Add("MaterialLayers", jArray);
+            }
 
             return jObject;
         }

--- a/SAM_Building/SAM.Core.Building/Classes/HostPartitionType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/HostPartitionType.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System.Collections.Generic;
 using System.Linq;
 using SAM.Architectural;

--- a/SAM_Building/SAM.Core.Building/Classes/HostPartitionTypeLibrary.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/HostPartitionTypeLibrary.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core;
 using System;
 using System.Collections.Generic;

--- a/SAM_Building/SAM.Core.Building/Classes/HostPartitionTypeLibrary.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/HostPartitionTypeLibrary.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core;
 using System;
 using System.Collections.Generic;
@@ -20,7 +20,7 @@ namespace SAM.Core.Building
 
         }
 
-        public HostPartitionTypeLibrary(JObject jObject)
+        public HostPartitionTypeLibrary(JsonObject jObject)
             : base(jObject)
         {
 
@@ -32,9 +32,9 @@ namespace SAM.Core.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
             {
                 return false;
             }
@@ -42,9 +42,9 @@ namespace SAM.Core.Building
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
             {
                 return jObject;

--- a/SAM_Building/SAM.Core.Building/Classes/InternalCondition.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/InternalCondition.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SAM_Building/SAM.Core.Building/Classes/InternalCondition.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/InternalCondition.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -42,7 +42,7 @@ namespace SAM.Core.Building
         {
         }
 
-        public InternalCondition(JObject jObject)
+        public InternalCondition(JsonObject jObject)
             : base(jObject)
         {
         }
@@ -158,17 +158,17 @@ namespace SAM.Core.Building
             return systemTypeLibrary.GetSystemTypes<T>(name).FirstOrDefault();
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return jObject;
 

--- a/SAM_Building/SAM.Core.Building/Classes/InternalConditionLibrary.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/InternalConditionLibrary.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System;
 using System.Collections.Generic;
 

--- a/SAM_Building/SAM.Core.Building/Classes/InternalConditionLibrary.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/InternalConditionLibrary.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using System;
 using System.Collections.Generic;
 
@@ -18,7 +18,7 @@ namespace SAM.Core.Building
 
         }
 
-        public InternalConditionLibrary(JObject jObject)
+        public InternalConditionLibrary(JsonObject jObject)
             : base(jObject)
         {
 
@@ -30,17 +30,17 @@ namespace SAM.Core.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return jObject;
 

--- a/SAM_Building/SAM.Core.Building/Classes/OpeningType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/OpeningType.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System.Collections.Generic;
 using SAM.Architectural;
 using System.Linq;

--- a/SAM_Building/SAM.Core.Building/Classes/OpeningType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/OpeningType.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-
+﻿using System.Text.Json.Nodes;
 using System.Collections.Generic;
 using SAM.Architectural;
 using System.Linq;
@@ -23,7 +22,7 @@ namespace SAM.Core.Building
 
         }
 
-        public OpeningType(JObject jObject)
+        public OpeningType(JsonObject jObject)
             : base(jObject)
         {
 
@@ -69,17 +68,17 @@ namespace SAM.Core.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
                 return jObject;

--- a/SAM_Building/SAM.Core.Building/Classes/OpeningTypeLibrary.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/OpeningTypeLibrary.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System;
 using System.Collections.Generic;
 

--- a/SAM_Building/SAM.Core.Building/Classes/OpeningTypeLibrary.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/OpeningTypeLibrary.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using System;
 using System.Collections.Generic;
 
@@ -18,7 +18,7 @@ namespace SAM.Core.Building
 
         }
 
-        public OpeningTypeLibrary(JObject jObject)
+        public OpeningTypeLibrary(JsonObject jObject)
             : base(jObject)
         {
 
@@ -30,17 +30,17 @@ namespace SAM.Core.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return jObject;
 

--- a/SAM_Building/SAM.Core.Building/Classes/Profile.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/Profile.cs
@@ -1,9 +1,10 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core;
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 
 namespace SAM.Core.Building
 {
@@ -155,7 +156,7 @@ namespace SAM.Core.Building
             }
         }
 
-        public Profile(JObject jObject)
+        public Profile(JsonObject jObject)
             : base(jObject)
         {
         }
@@ -798,53 +799,59 @@ namespace SAM.Core.Building
             return true;
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             if (jObject.ContainsKey("Category"))
-                category = jObject.Value<string>("Category");
+                category = jObject["Category"]?.GetValue<string>() ?? null;
 
             if (jObject.ContainsKey("Values"))
             {
-                JArray jArray = jObject.Value<JArray>("Values");
+                JsonArray jArray = jObject["Values"] as JsonArray;
                 if (jArray != null)
                 {
                     values = new SortedList<int, Tuple<Range<int>, AnyOf<double, Profile>>>();
 
-                    foreach (JToken jToken in jArray)
+                    foreach (JsonNode jsonNode in jArray)
                     {
-                        if (jToken.Type == JTokenType.Float)
+                        if (jsonNode == null)
                         {
-                            values[values.Count == 0 ? 0 : values.Keys.Max() + 1] = new Tuple<Range<int>, AnyOf<double, Profile>>(null, (double)jToken);
+                            continue;
                         }
-                        else if (jToken.Type == JTokenType.Array)
-                        {
-                            JArray jArray_Temp = (JArray)jToken;
 
-                            JToken jToken_Temp;
+                        if (jsonNode.GetValueKind() == JsonValueKind.Number)
+                        {
+                            values[values.Count == 0 ? 0 : values.Keys.Max() + 1] = new Tuple<Range<int>, AnyOf<double, Profile>>(null, jsonNode.GetValue<double>());
+                        }
+                        else if (jsonNode is JsonArray jArray_Temp)
+                        {
+                            JsonNode jsonNode_Temp;
+                            int key = jArray_Temp[0]?.GetValue<int>() ?? default(int);
+
 
                             switch (jArray_Temp.Count)
                             {
                                 case 1:
-                                    values[(int)jArray_Temp[0]] = null;
+                                    values[key] = null;
                                     break;
                                 case 2:
-                                    jToken_Temp = jArray_Temp[1];
-                                    if (jToken_Temp.Type == JTokenType.Float)
-                                        values[(int)jArray_Temp[0]] = new Tuple<Range<int>, AnyOf<double, Profile>>(null, (double)jToken_Temp);
-                                    else if (jToken_Temp.Type == JTokenType.Integer)
-                                        values[(int)jArray_Temp[0]] = new Tuple<Range<int>, AnyOf<double, Profile>>(new Range<int>((int)jArray_Temp[0], (int)jArray_Temp[1]), null);
-                                    else if (jToken_Temp.Type == JTokenType.Object)
-                                        values[(int)jArray_Temp[0]] = new Tuple<Range<int>, AnyOf<double, Profile>>(null, new Profile((JObject)jArray_Temp[1]));
+                                    jsonNode_Temp = jArray_Temp[1];
+                                    if (jsonNode_Temp is JsonValue jsonValue && jsonValue.TryGetValue<int>(out int max))
+                                        values[key] = new Tuple<Range<int>, AnyOf<double, Profile>>(new Range<int>(key, max), null);
+                                    else if (jsonNode_Temp?.GetValueKind() == JsonValueKind.Number)
+                                        values[key] = new Tuple<Range<int>, AnyOf<double, Profile>>(null, jsonNode_Temp.GetValue<double>());
+                                    else if (jsonNode_Temp is JsonObject jObject_Temp)
+                                        values[key] = new Tuple<Range<int>, AnyOf<double, Profile>>(null, new Profile(jObject_Temp));
                                     break;
                                 case 3:
-                                    jToken_Temp = jArray_Temp[2];
-                                    if (jToken_Temp.Type == JTokenType.Float)
-                                        values[(int)jArray_Temp[0]] = new Tuple<Range<int>, AnyOf<double, Profile>>(new Range<int>((int)jArray_Temp[0], (int)jArray_Temp[1]), (double)jToken_Temp);
-                                    else if (jToken_Temp.Type == JTokenType.Object)
-                                        values[(int)jArray_Temp[0]] = new Tuple<Range<int>, AnyOf<double, Profile>>(new Range<int>((int)jArray_Temp[0], (int)jArray_Temp[1]), new Profile((JObject)jToken_Temp));
+                                    jsonNode_Temp = jArray_Temp[2];
+                                    int rangeMax = jArray_Temp[1]?.GetValue<int>() ?? default(int);
+                                    if (jsonNode_Temp?.GetValueKind() == JsonValueKind.Number)
+                                        values[key] = new Tuple<Range<int>, AnyOf<double, Profile>>(new Range<int>(key, rangeMax), jsonNode_Temp.GetValue<double>());
+                                    else if (jsonNode_Temp is JsonObject jObject_Temp)
+                                        values[key] = new Tuple<Range<int>, AnyOf<double, Profile>>(new Range<int>(key, rangeMax), new Profile(jObject_Temp));
                                     break;
                             }
                         }
@@ -855,9 +862,9 @@ namespace SAM.Core.Building
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return jObject;
 
@@ -866,10 +873,10 @@ namespace SAM.Core.Building
 
             if (values != null)
             {
-                JArray jArray = new JArray();
+                JsonArray jArray = new JsonArray();
                 foreach (KeyValuePair<int, Tuple<Range<int>, AnyOf<double, Profile>>> keyValuePair in values)
                 {
-                    JArray jArray_Temp = new JArray();
+                    JsonArray jArray_Temp = new JsonArray();
                     jArray_Temp.Add(keyValuePair.Key);
 
                     Tuple<Range<int>, AnyOf<double, Profile>> tuple = keyValuePair.Value;
@@ -884,7 +891,7 @@ namespace SAM.Core.Building
                             if (value.Value is double)
                                 jArray_Temp.Add(value.Value);
                             else if (value.Value != null)
-                                jArray_Temp.Add((value.Value as Profile).ToJObject());
+                                jArray_Temp.Add((value.Value as Profile).ToJsonObject());
                         }
                     }
 

--- a/SAM_Building/SAM.Core.Building/Classes/Profile.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/Profile.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core;
 
 using System;

--- a/SAM_Building/SAM.Core.Building/Classes/ProfileLibrary.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/ProfileLibrary.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SAM_Building/SAM.Core.Building/Classes/ProfileLibrary.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/ProfileLibrary.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,7 +19,7 @@ namespace SAM.Core.Building
 
         }
 
-        public ProfileLibrary(JObject jObject)
+        public ProfileLibrary(JsonObject jObject)
             : base(jObject)
         {
 
@@ -41,17 +41,17 @@ namespace SAM.Core.Building
             }
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return jObject;
 

--- a/SAM_Building/SAM.Core.Building/Classes/RoofType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/RoofType.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using System.Collections.Generic;
 
 using SAM.Architectural;
@@ -13,7 +13,7 @@ namespace SAM.Core.Building
 
         }
 
-        public RoofType(JObject jObject)
+        public RoofType(JsonObject jObject)
             : base(jObject)
         {
 
@@ -49,17 +49,17 @@ namespace SAM.Core.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
                 return jObject;

--- a/SAM_Building/SAM.Core.Building/Classes/RoofType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/RoofType.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System.Collections.Generic;
 
 using SAM.Architectural;

--- a/SAM_Building/SAM.Core.Building/Classes/System/CoolingSystem.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/CoolingSystem.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-
+﻿using System.Text.Json.Nodes;
 namespace SAM.Core.Building
 {
     public class CoolingSystem : MechanicalSystem
@@ -22,22 +21,22 @@ namespace SAM.Core.Building
 
         }
 
-        public CoolingSystem(JObject jObject)
+        public CoolingSystem(JsonObject jObject)
             : base(jObject)
         {
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Core.Building/Classes/System/CoolingSystem.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/CoolingSystem.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 namespace SAM.Core.Building
 {
     public class CoolingSystem : MechanicalSystem

--- a/SAM_Building/SAM.Core.Building/Classes/System/CoolingSystemType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/CoolingSystemType.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using System;
 
 namespace SAM.Core.Building
@@ -24,23 +24,23 @@ namespace SAM.Core.Building
 
         }
 
-        public CoolingSystemType(JObject jObject)
+        public CoolingSystemType(JsonObject jObject)
             : base(jObject)
         {
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Core.Building/Classes/System/CoolingSystemType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/CoolingSystemType.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System;
 
 namespace SAM.Core.Building

--- a/SAM_Building/SAM.Core.Building/Classes/System/HeatingSystem.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/HeatingSystem.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 namespace SAM.Core.Building
 {
     public class HeatingSystem : MechanicalSystem

--- a/SAM_Building/SAM.Core.Building/Classes/System/HeatingSystem.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/HeatingSystem.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-
+﻿using System.Text.Json.Nodes;
 namespace SAM.Core.Building
 {
     public class HeatingSystem : MechanicalSystem
@@ -22,22 +21,22 @@ namespace SAM.Core.Building
 
         }
 
-        public HeatingSystem(JObject jObject)
+        public HeatingSystem(JsonObject jObject)
             : base(jObject)
         {
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Core.Building/Classes/System/HeatingSystemType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/HeatingSystemType.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System;
 
 namespace SAM.Core.Building

--- a/SAM_Building/SAM.Core.Building/Classes/System/HeatingSystemType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/HeatingSystemType.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using System;
 
 namespace SAM.Core.Building
@@ -24,23 +24,23 @@ namespace SAM.Core.Building
 
         }
 
-        public HeatingSystemType(JObject jObject)
+        public HeatingSystemType(JsonObject jObject)
             : base(jObject)
         {
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Core.Building/Classes/System/MechanicalSystem.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/MechanicalSystem.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 namespace SAM.Core.Building
 {
     public abstract class MechanicalSystem : SAMInstance<MechanicalSystemType>, ISystem, IBuildingObject

--- a/SAM_Building/SAM.Core.Building/Classes/System/MechanicalSystem.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/MechanicalSystem.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-
+﻿using System.Text.Json.Nodes;
 namespace SAM.Core.Building
 {
     public abstract class MechanicalSystem : SAMInstance<MechanicalSystemType>, ISystem, IBuildingObject
@@ -24,7 +23,7 @@ namespace SAM.Core.Building
             id = mechanicalSystem?.id;
         }
 
-        public MechanicalSystem(JObject jObject)
+        public MechanicalSystem(JsonObject jObject)
             : base(jObject)
         {
         }
@@ -45,22 +44,22 @@ namespace SAM.Core.Building
             }
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             if (jObject.ContainsKey("Id"))
             {
-                id = jObject.Value<string>("Id");
+                id = jObject["Id"]?.GetValue<string>() ?? null;
             }
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Core.Building/Classes/System/MechanicalSystemType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/MechanicalSystemType.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System;
 
 namespace SAM.Core.Building

--- a/SAM_Building/SAM.Core.Building/Classes/System/MechanicalSystemType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/MechanicalSystemType.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using System;
 
 namespace SAM.Core.Building
@@ -25,7 +25,7 @@ namespace SAM.Core.Building
             description = mechanicalSystemType.description;
         }
 
-        public MechanicalSystemType(JObject jObject)
+        public MechanicalSystemType(JsonObject jObject)
             : base(jObject)
         {
         }
@@ -38,20 +38,20 @@ namespace SAM.Core.Building
             }
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             if (jObject.ContainsKey("Description"))
-                description = jObject.Value<string>("Description");
+                description = jObject["Description"]?.GetValue<string>() ?? null;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Core.Building/Classes/System/VentilationSystem.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/VentilationSystem.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 namespace SAM.Core.Building
 {
     public class VentilationSystem : MechanicalSystem

--- a/SAM_Building/SAM.Core.Building/Classes/System/VentilationSystem.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/VentilationSystem.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-
+﻿using System.Text.Json.Nodes;
 namespace SAM.Core.Building
 {
     public class VentilationSystem : MechanicalSystem
@@ -22,22 +21,22 @@ namespace SAM.Core.Building
 
         }
 
-        public VentilationSystem(JObject jObject)
+        public VentilationSystem(JsonObject jObject)
             : base(jObject)
         {
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Core.Building/Classes/System/VentilationSystemType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/VentilationSystemType.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using System;
 
 namespace SAM.Core.Building
@@ -24,23 +24,23 @@ namespace SAM.Core.Building
 
         }
 
-        public VentilationSystemType(JObject jObject)
+        public VentilationSystemType(JsonObject jObject)
             : base(jObject)
         {
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Core.Building/Classes/System/VentilationSystemType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/System/VentilationSystemType.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System;
 
 namespace SAM.Core.Building

--- a/SAM_Building/SAM.Core.Building/Classes/WallType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/WallType.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System.Collections.Generic;
 
 using SAM.Architectural;

--- a/SAM_Building/SAM.Core.Building/Classes/WallType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/WallType.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using System.Collections.Generic;
 
 using SAM.Architectural;
@@ -19,7 +19,7 @@ namespace SAM.Core.Building
 
         }
 
-        public WallType(JObject jObject)
+        public WallType(JsonObject jObject)
             : base(jObject)
         {
 
@@ -49,17 +49,17 @@ namespace SAM.Core.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
                 return jObject;

--- a/SAM_Building/SAM.Core.Building/Classes/WindowType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/WindowType.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Architectural;
 using System.Collections.Generic;
 
@@ -18,7 +18,7 @@ namespace SAM.Core.Building
 
         }
 
-        public WindowType(JObject jObject)
+        public WindowType(JsonObject jObject)
             : base(jObject)
         {
 
@@ -48,17 +48,17 @@ namespace SAM.Core.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
                 return jObject;

--- a/SAM_Building/SAM.Core.Building/Classes/WindowType.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/WindowType.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Architectural;
 using System.Collections.Generic;
 

--- a/SAM_Building/SAM.Core.Building/Classes/Zone.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/Zone.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using System;
 
 namespace SAM.Core.Building

--- a/SAM_Building/SAM.Core.Building/Classes/Zone.cs
+++ b/SAM_Building/SAM.Core.Building/Classes/Zone.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using System;
 
 namespace SAM.Core.Building
@@ -29,22 +29,22 @@ namespace SAM.Core.Building
 
         }
 
-        public Zone(JObject jObject)
+        public Zone(JsonObject jObject)
             : base(jObject)
         {
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Core.Building/SAM.Core.Building.csproj
+++ b/SAM_Building/SAM.Core.Building/SAM.Core.Building.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.8" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.7" />
   </ItemGroup>
 </Project>

--- a/SAM_Building/SAM.Geometry.Building/Classes/AirPartition.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/AirPartition.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 using System;
@@ -14,7 +14,7 @@ namespace SAM.Geometry.Building
 
         }
 
-        public AirPartition(JObject jObject)
+        public AirPartition(JsonObject jObject)
             : base(jObject)
         {
 
@@ -38,9 +38,9 @@ namespace SAM.Geometry.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
             {
                 return false;
             }
@@ -49,9 +49,9 @@ namespace SAM.Geometry.Building
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
             {

--- a/SAM_Building/SAM.Geometry.Building/Classes/AirPartition.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/AirPartition.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 using System;

--- a/SAM_Building/SAM.Geometry.Building/Classes/BuildingElement.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/BuildingElement.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using SAM.Geometry.Object.Spatial;

--- a/SAM_Building/SAM.Geometry.Building/Classes/BuildingElement.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/BuildingElement.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-
+﻿using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using SAM.Geometry.Object.Spatial;
@@ -17,7 +16,7 @@ namespace SAM.Geometry.Building
             face3D = buildingElement?.Face3D?.Clone() as Face3D;
         }
 
-        public BuildingElement(JObject jObject)
+        public BuildingElement(JsonObject jObject)
             : base(jObject)
         {
 
@@ -75,24 +74,24 @@ namespace SAM.Geometry.Building
             face3D = face3D?.GetMoved(vector3D) as Face3D;
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
             {
                 return false;
             }
 
             if (jObject.ContainsKey("Face3D"))
             {
-                face3D = Geometry.Create.ISAMGeometry<Face3D>(jObject.Value<JObject>("Face3D"));
+                face3D = Geometry.Create.ISAMGeometry<Face3D>(jObject["Face3D"] as JsonObject);
             }
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
             {
@@ -101,7 +100,7 @@ namespace SAM.Geometry.Building
 
             if (face3D != null)
             {
-                jObject.Add("Face3D", face3D.ToJObject());
+                jObject.Add("Face3D", face3D.ToJsonObject());
             }
 
             return jObject;

--- a/SAM_Building/SAM.Geometry.Building/Classes/BuildingModel.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/BuildingModel.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Geometry.Spatial;
 using System;
@@ -22,7 +22,7 @@ namespace SAM.Geometry.Building
         private MaterialLibrary materialLibrary;
         private ProfileLibrary profileLibrary;
 
-        public BuildingModel(JObject jObject)
+        public BuildingModel(JsonObject jObject)
             : base(jObject)
         {
 
@@ -2368,38 +2368,38 @@ namespace SAM.Geometry.Building
             return new BoundingBox3D(boundingBox3Ds);
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             if (jObject.ContainsKey("Description"))
-                description = jObject.Value<string>("Description");
+                description = jObject["Description"]?.GetValue<string>() ?? null;
 
             if (jObject.ContainsKey("Location"))
-                location = new Location(jObject.Value<JObject>("Location"));
+                location = new Location(jObject["Location"] as JsonObject);
 
             if (jObject.ContainsKey("Address"))
-                address = new Address(jObject.Value<JObject>("Address"));
+                address = new Address(jObject["Address"] as JsonObject);
 
             if (jObject.ContainsKey("RelationCluster"))
-                relationCluster = new RelationCluster(jObject.Value<JObject>("RelationCluster"));
+                relationCluster = new RelationCluster(jObject["RelationCluster"] as JsonObject);
 
             if (jObject.ContainsKey("Terrain"))
-                terrain = Core.Create.IJSAMObject<Terrain>(jObject.Value<JObject>("Terrain"));
+                terrain = Core.Create.IJSAMObject<Terrain>(jObject["Terrain"] as JsonObject);
 
             if (jObject.ContainsKey("MaterialLibrary"))
-                materialLibrary = Core.Create.IJSAMObject<MaterialLibrary>(jObject.Value<JObject>("MaterialLibrary"));
+                materialLibrary = Core.Create.IJSAMObject<MaterialLibrary>(jObject["MaterialLibrary"] as JsonObject);
 
             if (jObject.ContainsKey("ProfileLibrary"))
-                profileLibrary = Core.Create.IJSAMObject<ProfileLibrary>(jObject.Value<JObject>("ProfileLibrary"));
+                profileLibrary = Core.Create.IJSAMObject<ProfileLibrary>(jObject["ProfileLibrary"] as JsonObject);
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return jObject;
 
@@ -2407,22 +2407,22 @@ namespace SAM.Geometry.Building
                 jObject.Add("Description", description);
 
             if (location != null)
-                jObject.Add("Location", location.ToJObject());
+                jObject.Add("Location", location.ToJsonObject());
 
             if (address != null)
-                jObject.Add("Address", address.ToJObject());
+                jObject.Add("Address", address.ToJsonObject());
 
             if (relationCluster != null)
-                jObject.Add("RelationCluster", relationCluster.ToJObject());
+                jObject.Add("RelationCluster", relationCluster.ToJsonObject());
 
             if (terrain != null)
-                jObject.Add("Terrain", terrain.ToJObject());
+                jObject.Add("Terrain", terrain.ToJsonObject());
 
             if (materialLibrary != null)
-                jObject.Add("MaterialLibrary", materialLibrary.ToJObject());
+                jObject.Add("MaterialLibrary", materialLibrary.ToJsonObject());
 
             if (profileLibrary != null)
-                jObject.Add("ProfileLibrary", profileLibrary.ToJObject());
+                jObject.Add("ProfileLibrary", profileLibrary.ToJsonObject());
 
             return jObject;
         }

--- a/SAM_Building/SAM.Geometry.Building/Classes/BuildingModel.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/BuildingModel.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Geometry.Spatial;
 using System;

--- a/SAM_Building/SAM.Geometry.Building/Classes/Door.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Door.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 
@@ -12,7 +12,7 @@ namespace SAM.Geometry.Building
 
         }
 
-        public Door(JObject jObject)
+        public Door(JsonObject jObject)
             : base(jObject)
         {
 
@@ -37,9 +37,9 @@ namespace SAM.Geometry.Building
         }
 
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
             {
                 return false;
             }
@@ -47,9 +47,9 @@ namespace SAM.Geometry.Building
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
             {

--- a/SAM_Building/SAM.Geometry.Building/Classes/Door.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Door.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 

--- a/SAM_Building/SAM.Geometry.Building/Classes/Floor.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Floor.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 
@@ -12,7 +12,7 @@ namespace SAM.Geometry.Building
 
         }
 
-        public Floor(JObject jObject)
+        public Floor(JsonObject jObject)
             : base(jObject)
         {
 
@@ -36,9 +36,9 @@ namespace SAM.Geometry.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
             {
                 return false;
             }
@@ -46,9 +46,9 @@ namespace SAM.Geometry.Building
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
             {

--- a/SAM_Building/SAM.Geometry.Building/Classes/Floor.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Floor.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 

--- a/SAM_Building/SAM.Geometry.Building/Classes/HostPartition.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/HostPartition.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Geometry.Spatial;
 using SAM.Geometry.Planar;

--- a/SAM_Building/SAM.Geometry.Building/Classes/HostPartition.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/HostPartition.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Geometry.Spatial;
 using SAM.Geometry.Planar;
@@ -18,7 +18,7 @@ namespace SAM.Geometry.Building
             openings = hostPartition?.openings?.ConvertAll(x => x.Clone());
         }
 
-        public HostPartition(JObject jObject)
+        public HostPartition(JsonObject jObject)
             : base(jObject)
         {
 
@@ -199,9 +199,9 @@ namespace SAM.Geometry.Building
             return openings.Find(x => x.Guid == guid)?.Clone();
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
             {
                 return false;
             }
@@ -210,9 +210,9 @@ namespace SAM.Geometry.Building
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
             {

--- a/SAM_Building/SAM.Geometry.Building/Classes/Opening.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Opening.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 using System.Collections.Generic;
@@ -14,7 +14,7 @@ namespace SAM.Geometry.Building
 
         }
 
-        public Opening(JObject jObject)
+        public Opening(JsonObject jObject)
             : base(jObject)
         {
 
@@ -174,9 +174,9 @@ namespace SAM.Geometry.Building
             return area_Frame / (area_Frame + area_Pane);
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
             {
                 return false;
             }
@@ -184,9 +184,9 @@ namespace SAM.Geometry.Building
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
             {

--- a/SAM_Building/SAM.Geometry.Building/Classes/Opening.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Opening.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 using System.Collections.Generic;

--- a/SAM_Building/SAM.Geometry.Building/Classes/Result/BuildingModelSimulationResult.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Result/BuildingModelSimulationResult.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using System;
@@ -31,22 +31,22 @@ namespace SAM.Geometry.Building
 
         }
 
-        public BuildingModelSimulationResult(JObject jObject)
+        public BuildingModelSimulationResult(JsonObject jObject)
             : base(jObject)
         {
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Geometry.Building/Classes/Result/BuildingModelSimulationResult.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Result/BuildingModelSimulationResult.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using System;

--- a/SAM_Building/SAM.Geometry.Building/Classes/Result/OpeningSimulationResult.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Result/OpeningSimulationResult.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using System;

--- a/SAM_Building/SAM.Geometry.Building/Classes/Result/OpeningSimulationResult.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Result/OpeningSimulationResult.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using System;
@@ -25,22 +25,22 @@ namespace SAM.Geometry.Building
 
         }
 
-        public OpeningSimulationResult(JObject jObject)
+        public OpeningSimulationResult(JsonObject jObject)
             : base(jObject)
         {
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Geometry.Building/Classes/Result/PartitionSimulationResult.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Result/PartitionSimulationResult.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using System;
@@ -25,22 +25,22 @@ namespace SAM.Geometry.Building
 
         }
 
-        public PartitionSimulationResult(JObject jObject)
+        public PartitionSimulationResult(JsonObject jObject)
             : base(jObject)
         {
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Geometry.Building/Classes/Result/PartitionSimulationResult.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Result/PartitionSimulationResult.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using System;

--- a/SAM_Building/SAM.Geometry.Building/Classes/Result/SpaceSimulationResult.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Result/SpaceSimulationResult.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using System;
@@ -31,22 +31,22 @@ namespace SAM.Geometry.Building
 
         }
 
-        public SpaceSimulationResult(JObject jObject)
+        public SpaceSimulationResult(JsonObject jObject)
             : base(jObject)
         {
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Geometry.Building/Classes/Result/SpaceSimulationResult.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Result/SpaceSimulationResult.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using System;

--- a/SAM_Building/SAM.Geometry.Building/Classes/Result/ZoneSimulationResult.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Result/ZoneSimulationResult.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using System;
@@ -25,22 +25,22 @@ namespace SAM.Geometry.Building
 
         }
 
-        public ZoneSimulationResult(JObject jObject)
+        public ZoneSimulationResult(JsonObject jObject)
             : base(jObject)
         {
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return null;
 

--- a/SAM_Building/SAM.Geometry.Building/Classes/Result/ZoneSimulationResult.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Result/ZoneSimulationResult.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using System;

--- a/SAM_Building/SAM.Geometry.Building/Classes/Roof.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Roof.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 

--- a/SAM_Building/SAM.Geometry.Building/Classes/Roof.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Roof.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 
@@ -12,7 +12,7 @@ namespace SAM.Geometry.Building
 
         }
 
-        public Roof(JObject jObject)
+        public Roof(JsonObject jObject)
             : base(jObject)
         {
 
@@ -34,9 +34,9 @@ namespace SAM.Geometry.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
             {
                 return false;
             }
@@ -44,9 +44,9 @@ namespace SAM.Geometry.Building
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
             {

--- a/SAM_Building/SAM.Geometry.Building/Classes/Space.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Space.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using SAM.Geometry.Object.Spatial;
@@ -69,7 +69,7 @@ namespace SAM.Geometry.Building
             }
         }
 
-        public Space(JObject jObject)
+        public Space(JsonObject jObject)
             : base(jObject)
         {
         }
@@ -109,31 +109,31 @@ namespace SAM.Geometry.Building
             }
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
                 return false;
 
             if (jObject.ContainsKey("Location"))
-                location = new Point3D(jObject.Value<JObject>("Location"));
+                location = new Point3D(jObject["Location"] as JsonObject);
 
             if (jObject.ContainsKey("InternalCondition"))
-                internalCondition = new InternalCondition(jObject.Value<JObject>("InternalCondition"));
+                internalCondition = new InternalCondition(jObject["InternalCondition"] as JsonObject);
 
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
             if (jObject == null)
                 return jObject;
 
             if (location != null)
-                jObject.Add("Location", location.ToJObject());
+                jObject.Add("Location", location.ToJsonObject());
 
             if (internalCondition != null)
-                jObject.Add("InternalCondition", internalCondition.ToJObject());
+                jObject.Add("InternalCondition", internalCondition.ToJsonObject());
 
             return jObject;
         }

--- a/SAM_Building/SAM.Geometry.Building/Classes/Space.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Space.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core;
 using SAM.Core.Building;
 using SAM.Geometry.Object.Spatial;

--- a/SAM_Building/SAM.Geometry.Building/Classes/Wall.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Wall.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 
@@ -12,7 +12,7 @@ namespace SAM.Geometry.Building
 
         }
 
-        public Wall(JObject jObject)
+        public Wall(JsonObject jObject)
             : base(jObject)
         {
 
@@ -36,9 +36,9 @@ namespace SAM.Geometry.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
             {
                 return false;
             }
@@ -46,9 +46,9 @@ namespace SAM.Geometry.Building
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
             {

--- a/SAM_Building/SAM.Geometry.Building/Classes/Wall.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Wall.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 

--- a/SAM_Building/SAM.Geometry.Building/Classes/Window.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Window.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 
@@ -12,7 +12,7 @@ namespace SAM.Geometry.Building
 
         }
 
-        public Window(JObject jObject)
+        public Window(JsonObject jObject)
             : base(jObject)
         {
 
@@ -36,9 +36,9 @@ namespace SAM.Geometry.Building
 
         }
 
-        public override bool FromJObject(JObject jObject)
+        public override bool FromJsonObject(JsonObject jObject)
         {
-            if (!base.FromJObject(jObject))
+            if (!base.FromJsonObject(jObject))
             {
                 return false;
             }
@@ -46,9 +46,9 @@ namespace SAM.Geometry.Building
             return true;
         }
 
-        public override JObject ToJObject()
+        public override JsonObject ToJsonObject()
         {
-            JObject jObject = base.ToJObject();
+            JsonObject jObject = base.ToJsonObject();
 
             if (jObject == null)
             {

--- a/SAM_Building/SAM.Geometry.Building/Classes/Window.cs
+++ b/SAM_Building/SAM.Geometry.Building/Classes/Window.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using System.Text.Json.Nodes;
 using SAM.Core.Building;
 using SAM.Geometry.Spatial;
 

--- a/SAM_Building/SAM.Geometry.Building/Create/HostPartitions.cs
+++ b/SAM_Building/SAM.Geometry.Building/Create/HostPartitions.cs
@@ -1,4 +1,6 @@
-﻿using SAM.Geometry.Building;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+using SAM.Geometry.Building;
 using SAM.Geometry.Spatial;
 using System.Collections.Generic;
 

--- a/SAM_Building/SAM.Geometry.Building/Create/HostPartitions.cs
+++ b/SAM_Building/SAM.Geometry.Building/Create/HostPartitions.cs
@@ -43,7 +43,7 @@ namespace SAM.Geometry.Building
                 closedPlanar3Ds.Add(face3D);
             }
 
-            List<Polygon3D> polygon3Ds = Geometry.Spatial.Create.Polygon3Ds(closedPlanar3Ds, plane, checkIntersection, tolerance_Distance);
+            List<Polygon3D> polygon3Ds = Geometry.Spatial.Create.Polygon3Ds(closedPlanar3Ds, plane, checkIntersection, true, tolerance_Distance);
             if (polygon3Ds == null || polygon3Ds.Count == 0)
             {
                 return null;

--- a/SAM_Building/SAM.Geometry.Building/SAM.Geometry.Building.csproj
+++ b/SAM_Building/SAM.Geometry.Building/SAM.Geometry.Building.csproj
@@ -44,7 +44,7 @@
       <Version>2.5.0</Version>
     </PackageReference>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SAM.Core.Building\SAM.Core.Building.csproj" />


### PR DESCRIPTION
## Summary

Quarterly Q2 2026 work from the SAM-BIM fork merging back into the upstream.
Includes the **Newtonsoft.Json → System.Text.Json.Nodes** migration of the
entire SAM-BIM stack (per-repo PRs already merged into SAM-BIM's `sow/2026-Q2`).

## Highlights of this quarter

- All `IJSAMObject` implementations migrated from `JObject`/`JArray`/`JToken` to
  `JsonObject`/`JsonArray`/`JsonNode`.
- `FromJObject` / `ToJObject` renamed to `FromJsonObject` / `ToJsonObject`.
- `System.Text.Json` 10.0.8 replaces `Newtonsoft.Json` 13.0.3 in every csproj
  (except SAM_Revit which keeps Newtonsoft loadable for Revit's runtime).
- Wire format preserved bit-for-bit (14 fixture round-trip tests in SAM/SAM.Tests).
- 5 latent pre-existing bugs fixed (DateTime/string bleed, NCMData enum round-trip,
  Log identity loss, SearchWrapper missing type discriminator, RelationCollection
  wrong-jObject-passed).

## Verification

- Full `BuildAlls_v3 RestoreCleanRebuild` against the merged sow/2026-Q2 chain:
  **0 errors, 144 artifacts**.
- All 32 per-repo migration PRs on SAM-BIM:sow/2026-Q2 passed build + spdx CI.
- Local Rhino / Revit / Tas runtime smoke validated.

## Test plan

- [ ] Upstream CI builds (if configured)
- [ ] Reviewer spot-check of `IJSAMObject` API rename
- [ ] After merge, downstream forks sync `master` from upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)
